### PR TITLE
Move to Vec to be able to manage FileSources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-chunky-vec = "0.1"
 fluent-bundle = "0.14"
 fluent-fallback = "0.2"
 fluent-testing = { git = "https://github.com/projectfluent/fluent-rs", optional = true, features = ["sync", "async"] }


### PR DESCRIPTION
Fixes #9.

@djg @manishearth - I tried to go with the "simplest" approach and just used a `Vec` for storing sources on the registry. I don't see much impact on the criterion benchmark.

I understand that `slab` may be faster, but the code is not really that hot. In most cases we have just 2 sources, sometimes 4, max 6, and they're stable throughout the lifetime of the process. So really the only hot path is to get the number of sources, and retrieve a source by its index (`get(idx)`). And it seems that `Vec` is doing just fine here for as far as I can see.

In order to unblock landing of the l10nregistry-rs, I'd like to switch to that unless you think I should look into `slab` for memory/perf reasons that I haven't identify yet.