### PR TITLE
Add catastrophic scenario to solver for benchmarks

### DIFF
--- a/src/solver/testing/scenarios.rs
+++ b/src/solver/testing/scenarios.rs
@@ -147,5 +147,17 @@ pub fn get_scenarios() -> Vec<Scenario> {
                 vec![3, 3, 3],
             ],
         ),
+        Scenario::new(
+            "catastrophic",
+            4,
+            21,
+            vec![
+                vec![true; 21],
+                vec![true; 21],
+                vec![true; 21],
+                vec![true; 21],
+            ],
+            vec![],
+        ),
     ]
 }


### PR DESCRIPTION
Draft PR adding a case for https://bugzilla.mozilla.org/show_bug.cgi?id=1642415 bug.

Reproduce with `cargo bench solver/serial/catastrophic --all-features`

Current result: the solver itself takes ~3ms on my machine for that scenario, while all other scenarios are within nanoseconds.
It generates `194481` combinations and once plugged into real L10nRegistry/Localization setup for each it has to generate Bundle, and test against it.