### PR TITLE
Add metasources to l10nregistry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,11 @@ name = "solver"
 harness = false
 required-features = ["tokio", "fluent-testing"]
 
+[[bench]]
+name = "registry"
+harness = false
+required-features = [] #"tokio", "fluent-testing"]
+
 [[test]]
 name = "source"
 path = "tests/source.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "l10nregistry"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Zibi Braniecki <gandalf@mozilla.com>"]
 license = "Apache-2.0/MIT"
 edition = "2018"
@@ -49,7 +49,7 @@ required-features = ["tokio", "fluent-testing"]
 [[bench]]
 name = "registry"
 harness = false
-required-features = [] #"tokio", "fluent-testing"]
+required-features = ["tokio", "fluent-testing"]
 
 [[test]]
 name = "source"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,18 +29,22 @@ tokio-io = ["tokio"]
 [[bench]]
 name = "preferences"
 harness = false
+required-features = ["tokio", "fluent-testing"]
 
 [[bench]]
 name = "localization"
 harness = false
+required-features = ["tokio", "fluent-testing"]
 
 [[bench]]
 name = "source"
 harness = false
+required-features = ["tokio", "fluent-testing"]
 
 [[bench]]
 name = "solver"
 harness = false
+required-features = ["tokio", "fluent-testing"]
 
 [[test]]
 name = "source"

--- a/benches/registry.rs
+++ b/benches/registry.rs
@@ -37,10 +37,10 @@ fn registry_bench(c: &mut Criterion) {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
         ],
         vec![en_us.clone()],
     );
@@ -74,27 +74,27 @@ fn registry_metasource_bench(c: &mut Criterion) {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "toolkit",
-                "app",
+                Some("app"),
                 vec![en_us.clone()],
                 "toolkit/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "browser",
-                "app",
+                Some("app"),
                 vec![en_us.clone()],
                 "browser/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "toolkit",
-                "langpack",
+                Some("langpack"),
                 vec![en_us.clone()],
                 "toolkit/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "browser",
-                "langpack",
+                Some("langpack"),
                 vec![en_us.clone()],
                 "browser/{locale}/",
             ),

--- a/benches/registry.rs
+++ b/benches/registry.rs
@@ -1,0 +1,113 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+
+use l10nregistry::testing::{FileSource, RegistrySetup, TestFileFetcher};
+use unic_langid::LanguageIdentifier;
+
+fn get_paths() -> Vec<String> {
+    let paths: Vec<&'static str> = vec![
+        "branding/brand.ftl",
+        "browser/sanitize.ftl",
+        "browser/preferences/blocklists.ftl",
+        "browser/preferences/colors.ftl",
+        "browser/preferences/selectBookmark.ftl",
+        "browser/preferences/connection.ftl",
+        "browser/preferences/addEngine.ftl",
+        "browser/preferences/siteDataSettings.ftl",
+        "browser/preferences/fonts.ftl",
+        "browser/preferences/languages.ftl",
+        "browser/preferences/preferences.ftl",
+        "security/certificates/certManager.ftl",
+        "security/certificates/deviceManager.ftl",
+        "toolkit/global/textActions.ftl",
+        "toolkit/printing/printUI.ftl",
+        "toolkit/updates/history.ftl",
+        "toolkit/featuregates/features.ftl",
+    ];
+
+    paths.iter().map(|s| s.to_string()).collect()
+}
+
+fn registry_bench(c: &mut Criterion) {
+    let en_us: LanguageIdentifier = "en-US".parse().unwrap();
+    let mut group = c.benchmark_group("non-metasource");
+
+    let setup = RegistrySetup::new(
+        "test",
+        vec![
+            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+        ],
+        vec![en_us.clone()],
+    );
+    let fetcher = TestFileFetcher::new();
+    let (_, reg) = fetcher.get_registry_and_environment(setup);
+
+    group.bench_function(&format!("serial",), |b| {
+        b.iter(|| {
+            let lang_ids = vec![en_us.clone()];
+            let mut i = reg.generate_bundles_sync(lang_ids.into_iter(), get_paths());
+            while let Some(_) = i.next() {}
+        })
+    });
+
+    group.finish();
+}
+
+fn registry_metasource_bench(c: &mut Criterion) {
+    let en_us: LanguageIdentifier = "en-US".parse().unwrap();
+    let mut group = c.benchmark_group("metasource");
+
+    let setup = RegistrySetup::new(
+        "test",
+        vec![
+            FileSource::new_with_metasource(
+                "toolkit",
+                "app",
+                vec![en_us.clone()],
+                "toolkit/{locale}/",
+            ),
+            FileSource::new_with_metasource(
+                "browser",
+                "app",
+                vec![en_us.clone()],
+                "browser/{locale}/",
+            ),
+            FileSource::new_with_metasource(
+                "toolkit",
+                "langpack",
+                vec![en_us.clone()],
+                "toolkit/{locale}/",
+            ),
+            FileSource::new_with_metasource(
+                "browser",
+                "langpack",
+                vec![en_us.clone()],
+                "browser/{locale}/",
+            ),
+        ],
+        vec![en_us.clone()],
+    );
+    let fetcher = TestFileFetcher::new();
+    let (_, reg) = fetcher.get_registry_and_environment(setup);
+
+    group.bench_function(&format!("serial",), |b| {
+        b.iter(|| {
+            let lang_ids = vec![en_us.clone()];
+            let mut i = reg.generate_bundles_sync(lang_ids.into_iter(), get_paths());
+            while let Some(_) = i.next() {}
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = registry_bench, registry_metasource_bench
+);
+criterion_main!(benches);

--- a/benches/registry.rs
+++ b/benches/registry.rs
@@ -2,9 +2,9 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
 
+use futures::stream::StreamExt;
 use l10nregistry::testing::{FileSource, RegistrySetup, TestFileFetcher};
 use unic_langid::LanguageIdentifier;
-use futures::stream::StreamExt;
 
 fn get_paths() -> Vec<String> {
     let paths: Vec<&'static str> = vec![

--- a/benches/source.rs
+++ b/benches/source.rs
@@ -27,7 +27,9 @@ fn source_bench(c: &mut Criterion) {
         let sources: Vec<_> = scenario
             .file_sources
             .iter()
-            .map(|s| fetcher.get_test_file_source(&s.name, get_locales(&s.locales), &s.path_scheme))
+            .map(|s| {
+                fetcher.get_test_file_source(&s.name, None, get_locales(&s.locales), &s.path_scheme)
+            })
             .collect();
 
         group.bench_function(format!("{}/has_file", scenario.name), |b| {

--- a/src/registry/asynchronous.rs
+++ b/src/registry/asynchronous.rs
@@ -201,7 +201,7 @@ where
             } else if let Some(locale) = self.locales.next() {
                 let solver = ParallelProblemSolver::new(
                     self.res_ids.len(),
-                    self.reg.lock().len(0 /* TODO */),
+                    self.reg.lock().metasource_len(0 /* TODO */),
                 );
                 self.state = State::Solver { locale, solver };
             } else {

--- a/src/registry/asynchronous.rs
+++ b/src/registry/asynchronous.rs
@@ -213,6 +213,9 @@ where
                     }
                 }
             } else if let Some(locale) = self.locales.next() {
+                if self.reg.lock().number_of_metasources() == 0 {
+                    return None.into();
+                }
                 let number_of_metasources = self.reg.lock().number_of_metasources() - 1;
                 self.current_metasource = number_of_metasources;
                 let solver = ParallelProblemSolver::new(

--- a/src/registry/asynchronous.rs
+++ b/src/registry/asynchronous.rs
@@ -133,7 +133,8 @@ impl<'l, P, B> AsyncTester for GenerateBundles<P, B> {
             .iter()
             .map(|(res_idx, source_idx)| {
                 let res = &self.res_ids[*res_idx];
-                lock.source_idx(*source_idx).fetch_file(locale, res)
+                lock.source_idx(0 /*TODO*/, *source_idx)
+                    .fetch_file(locale, res)
             })
             .collect::<FuturesOrdered<_>>();
         TestResult(stream.collect())
@@ -164,6 +165,7 @@ where
                         Ok(Some(order)) => {
                             let locale = self.state.get_locale();
                             let bundle = self.reg.lock().bundle_from_order(
+                                0, /* TODO */
                                 locale.clone(),
                                 &order,
                                 &self.res_ids,
@@ -197,7 +199,10 @@ where
                     }
                 }
             } else if let Some(locale) = self.locales.next() {
-                let solver = ParallelProblemSolver::new(self.res_ids.len(), self.reg.lock().len());
+                let solver = ParallelProblemSolver::new(
+                    self.res_ids.len(),
+                    self.reg.lock().len(0 /* TODO */),
+                );
                 self.state = State::Solver { locale, solver };
             } else {
                 return None.into();

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -23,44 +23,53 @@ pub type FluentResourceSet = Vec<Rc<FluentResource>>;
 
 #[derive(Default)]
 struct Shared<P, B> {
-    sources: RefCell<Vec<FileSource>>,
+    sources: RefCell<Vec<Vec<FileSource>>>,
     provider: P,
     bundle_adapter: Option<B>,
 }
 
 pub struct L10nRegistryLocked<'a, B> {
-    lock: Ref<'a, Vec<FileSource>>,
+    lock: Ref<'a, Vec<Vec<FileSource>>>,
     bundle_adapter: Option<&'a B>,
 }
 
 impl<'a, B> L10nRegistryLocked<'a, B> {
-    pub fn iter(&self) -> impl Iterator<Item = &FileSource> {
-        self.lock.iter()
+    pub fn iter(&self, metasource: usize) -> impl Iterator<Item = &FileSource> {
+        self.lock[metasource].iter()
     }
 
-    pub fn len(&self) -> usize {
+    pub fn metasources_len(&self) -> usize {
         self.lock.len()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub fn len(&self, metasource: usize) -> usize {
+        self.lock[metasource].len()
     }
 
-    pub fn source_idx(&self, index: usize) -> &FileSource {
-        let source_idx = self.len() - 1 - index;
-        self.lock.get(source_idx).expect("Index out-of-range")
+    pub fn is_empty(&self, metasource: usize) -> bool {
+        self.len(metasource) == 0
     }
 
-    pub fn get_source(&self, name: &str) -> Option<&FileSource> {
-        self.lock.iter().find(|&source| source.name == name)
+    pub fn source_idx(&self, metasource: usize, index: usize) -> &FileSource {
+        let source_idx = self.len(metasource) - 1 - index;
+        self.lock[metasource]
+            .get(source_idx)
+            .expect("Index out-of-range")
+    }
+
+    pub fn get_source(&self, metasource: usize, name: &str) -> Option<&FileSource> {
+        self.lock[metasource]
+            .iter()
+            .find(|&source| source.name == name)
     }
 
     pub fn generate_sources_for_file<'l>(
         &'l self,
+        metasource: usize,
         langid: &'l LanguageIdentifier,
         res_id: &'l str,
     ) -> impl Iterator<Item = &FileSource> {
-        self.iter()
+        self.iter(metasource)
             .filter(move |source| source.has_file(langid, res_id) != Some(false))
     }
 }
@@ -112,12 +121,14 @@ impl<P, B> L10nRegistry<P, B> {
             .map_err(|_| L10nRegistrySetupError::RegistryLocked)?;
 
         for new_source in new_sources {
-            if sources.iter().any(|source| source == &new_source) {
-                return Err(L10nRegistrySetupError::DuplicatedSource {
-                    name: new_source.name,
-                });
+            if let Some(metasource) = sources
+                .iter_mut()
+                .find(|source| source[0].metasource == new_source.metasource)
+            {
+                metasource.push(new_source);
+            } else {
+                sources.push(vec![new_source]);
             }
-            sources.push(new_source);
         }
         Ok(())
     }
@@ -133,12 +144,17 @@ impl<P, B> L10nRegistry<P, B> {
             .map_err(|_| L10nRegistrySetupError::RegistryLocked)?;
 
         for upd_source in upd_sources {
-            if let Some(idx) = sources.iter().position(|source| *source == upd_source) {
-                *sources.get_mut(idx).unwrap() = upd_source;
-            } else {
-                return Err(L10nRegistrySetupError::MissingSource {
-                    name: upd_source.name,
-                });
+            if let Some(metasource) = sources
+                .iter_mut()
+                .find(|source| source[0].metasource == upd_source.metasource)
+            {
+                if let Some(idx) = metasource.iter().position(|source| *source == upd_source) {
+                    *metasource.get_mut(idx).unwrap() = upd_source;
+                } else {
+                    return Err(L10nRegistrySetupError::MissingSource {
+                        name: upd_source.name,
+                    });
+                }
             }
         }
         Ok(())
@@ -155,7 +171,9 @@ impl<P, B> L10nRegistry<P, B> {
             .map_err(|_| L10nRegistrySetupError::RegistryLocked)?;
         let del_sources: Vec<String> = del_sources.into_iter().map(|s| s.to_string()).collect();
 
-        sources.retain(|source| !del_sources.contains(&source.name));
+        for metasource in sources.iter_mut() {
+            metasource.retain(|source| !del_sources.contains(&source.name));
+        }
         Ok(())
     }
 
@@ -175,7 +193,7 @@ impl<P, B> L10nRegistry<P, B> {
             .sources
             .try_borrow_mut()
             .map_err(|_| L10nRegistrySetupError::RegistryLocked)?;
-        Ok(sources.iter().map(|s| s.name.clone()).collect())
+        Ok(sources.iter().flatten().map(|s| s.name.clone()).collect())
     }
 
     pub fn has_source(&self, name: &str) -> Result<bool, L10nRegistrySetupError> {
@@ -184,7 +202,7 @@ impl<P, B> L10nRegistry<P, B> {
             .sources
             .try_borrow_mut()
             .map_err(|_| L10nRegistrySetupError::RegistryLocked)?;
-        Ok(sources.iter().any(|source| source.name == name))
+        Ok(sources.iter().flatten().any(|source| source.name == name))
     }
 
     pub fn get_source(&self, name: &str) -> Result<Option<FileSource>, L10nRegistrySetupError> {
@@ -193,9 +211,12 @@ impl<P, B> L10nRegistry<P, B> {
             .sources
             .try_borrow_mut()
             .map_err(|_| L10nRegistrySetupError::RegistryLocked)?;
-        Ok(sources.iter().find(|source| source.name == name).cloned())
+        Ok(sources
+            .iter()
+            .flatten()
+            .find(|source| source.name == name)
+            .cloned())
     }
-
     pub fn get_available_locales(&self) -> Result<Vec<LanguageIdentifier>, L10nRegistrySetupError> {
         let sources = self
             .shared
@@ -203,7 +224,7 @@ impl<P, B> L10nRegistry<P, B> {
             .try_borrow_mut()
             .map_err(|_| L10nRegistrySetupError::RegistryLocked)?;
         let mut result = HashSet::new();
-        for source in sources.iter() {
+        for source in sources.iter().flatten() {
             for locale in source.locales() {
                 result.insert(locale);
             }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -35,30 +35,31 @@ pub struct L10nRegistryLocked<'a, B> {
 
 impl<'a, B> L10nRegistryLocked<'a, B> {
     pub fn iter(&self, metasource: usize) -> impl Iterator<Item = &FileSource> {
-        self.lock[metasource].iter()
+        self.lock
+            .get(metasource)
+            .expect("Index out-of-range")
+            .iter()
     }
 
-    pub fn metasources_len(&self) -> usize {
+    pub fn number_of_metasources(&self) -> usize {
         self.lock.len()
     }
 
-    pub fn len(&self, metasource: usize) -> usize {
-        self.lock[metasource].len()
-    }
-
-    pub fn is_empty(&self, metasource: usize) -> bool {
-        self.len(metasource) == 0
+    pub fn metasource_len(&self, metasource: usize) -> usize {
+        self.lock.get(metasource).expect("Index out-of-range").len()
     }
 
     pub fn source_idx(&self, metasource: usize, index: usize) -> &FileSource {
-        let source_idx = self.len(metasource) - 1 - index;
+        let source_idx = self.metasource_len(metasource) - 1 - index;
         self.lock[metasource]
             .get(source_idx)
             .expect("Index out-of-range")
     }
 
     pub fn get_source(&self, metasource: usize, name: &str) -> Option<&FileSource> {
-        self.lock[metasource]
+        self.lock
+            .get(metasource)
+            .expect("Index out-of-range")
             .iter()
             .find(|&source| source.name == name)
     }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -175,6 +175,9 @@ impl<P, B> L10nRegistry<P, B> {
         for metasource in sources.iter_mut() {
             metasource.retain(|source| !del_sources.contains(&source.name));
         }
+
+        sources.retain(|metasource| !metasource.is_empty());
+
         Ok(())
     }
 

--- a/src/registry/synchronous.rs
+++ b/src/registry/synchronous.rs
@@ -10,6 +10,7 @@ use unic_langid::LanguageIdentifier;
 impl<'a, B> L10nRegistryLocked<'a, B> {
     pub(crate) fn bundle_from_order<P>(
         &self,
+        metasource: usize,
         locale: LanguageIdentifier,
         source_order: &[usize],
         res_ids: &[String],
@@ -28,7 +29,7 @@ impl<'a, B> L10nRegistryLocked<'a, B> {
         let mut errors = vec![];
 
         for (&source_idx, path) in source_order.iter().zip(res_ids.iter()) {
-            let source = self.source_idx(source_idx);
+            let source = self.source_idx(metasource, source_idx);
             if let Some(res) = source.fetch_file_sync(&locale, path, /* overload */ true) {
                 if source.options.allow_override {
                     bundle.add_resource_overriding(res);
@@ -119,6 +120,7 @@ impl State {
 pub struct GenerateBundlesSync<P, B> {
     reg: L10nRegistry<P, B>,
     locales: std::vec::IntoIter<LanguageIdentifier>,
+    current_metasource: usize,
     res_ids: Vec<String>,
     state: State,
 }
@@ -132,6 +134,7 @@ impl<P, B> GenerateBundlesSync<P, B> {
         Self {
             reg,
             locales,
+            current_metasource: 0,
             res_ids,
             state: State::Empty,
         }
@@ -144,7 +147,7 @@ impl<P, B> SyncTester for GenerateBundlesSync<P, B> {
         let res = &self.res_ids[res_idx];
         self.reg
             .lock()
-            .source_idx(source_idx)
+            .source_idx(self.current_metasource, source_idx)
             .fetch_file_sync(locale, res, /* overload */ true)
             .is_some()
     }
@@ -171,7 +174,10 @@ where
         }
 
         if let Some(locale) = self.locales.next() {
-            let mut solver = SerialProblemSolver::new(self.res_ids.len(), self.reg.lock().len());
+            let mut solver = SerialProblemSolver::new(
+                self.res_ids.len(),
+                self.reg.lock().len(self.current_metasource),
+            );
             self.state = State::Locale(locale.clone());
             if let Err(idx) = solver.try_next(self, true) {
                 self.reg
@@ -202,8 +208,9 @@ where
                     Ok(Some(order)) => {
                         let locale = self.state.get_locale();
                         let bundle = self.reg.lock().bundle_from_order(
+                            self.current_metasource,
                             locale.clone(),
-                            order,
+                            &order,
                             &self.res_ids,
                             &self.reg.shared.provider,
                         );
@@ -227,8 +234,31 @@ where
                 self.state = State::Empty;
             }
 
+            if let State::Solver {
+                locale: _,
+                solver: _,
+            } = self.state
+            {
+                if self.current_metasource > 0 {
+                    self.current_metasource -= 1;
+                    let solver = SerialProblemSolver::new(
+                        self.res_ids.len(),
+                        self.reg.lock().len(self.current_metasource),
+                    );
+                    self.state = State::Solver {
+                        locale: self.state.get_locale().clone(),
+                        solver,
+                    };
+                    continue;
+                }
+            }
+
             let locale = self.locales.next()?;
-            let solver = SerialProblemSolver::new(self.res_ids.len(), self.reg.lock().len());
+            self.current_metasource = self.reg.lock().metasources_len() - 1;
+            let solver = SerialProblemSolver::new(
+                self.res_ids.len(),
+                self.reg.lock().len(self.current_metasource),
+            );
             self.state = State::Solver { locale, solver };
         }
     }

--- a/src/registry/synchronous.rs
+++ b/src/registry/synchronous.rs
@@ -191,6 +191,23 @@ where
     }
 }
 
+macro_rules! try_next_metasource {
+    ( $self:ident ) => {{
+        if $self.current_metasource > 0 {
+            $self.current_metasource -= 1;
+            let solver = SerialProblemSolver::new(
+                $self.res_ids.len(),
+                $self.reg.lock().metasource_len($self.current_metasource),
+            );
+            $self.state = State::Solver {
+                locale: $self.state.get_locale().clone(),
+                solver,
+            };
+            continue;
+        }
+    }};
+}
+
 impl<P, B> Iterator for GenerateBundlesSync<P, B>
 where
     P: ErrorReporter,
@@ -220,20 +237,12 @@ where
                         }
                     }
                     Ok(None) => {
-                        if self.current_metasource > 0 {
-                            self.current_metasource -= 1;
-                            let solver = SerialProblemSolver::new(
-                                self.res_ids.len(),
-                                self.reg.lock().metasource_len(self.current_metasource),
-                            );
-                            self.state = State::Solver {
-                                locale: self.state.get_locale().clone(),
-                                solver,
-                            };
-                            continue;
-                        }
+                        try_next_metasource!(self);
                     }
                     Err(idx) => {
+                        try_next_metasource!(self);
+                        // Only signal an error if we run out of metasources
+                        // to try.
                         self.reg.shared.provider.report_errors(vec![
                             L10nRegistryError::MissingResource {
                                 locale: self.state.get_locale().clone(),

--- a/src/registry/synchronous.rs
+++ b/src/registry/synchronous.rs
@@ -246,6 +246,9 @@ where
             }
 
             let locale = self.locales.next()?;
+            if self.reg.lock().number_of_metasources() == 0 {
+                return None;
+            }
             self.current_metasource = self.reg.lock().number_of_metasources() - 1;
             let solver = SerialProblemSolver::new(
                 self.res_ids.len(),

--- a/src/registry/synchronous.rs
+++ b/src/registry/synchronous.rs
@@ -176,7 +176,7 @@ where
         if let Some(locale) = self.locales.next() {
             let mut solver = SerialProblemSolver::new(
                 self.res_ids.len(),
-                self.reg.lock().len(self.current_metasource),
+                self.reg.lock().metasource_len(self.current_metasource),
             );
             self.state = State::Locale(locale.clone());
             if let Err(idx) = solver.try_next(self, true) {
@@ -243,7 +243,7 @@ where
                     self.current_metasource -= 1;
                     let solver = SerialProblemSolver::new(
                         self.res_ids.len(),
-                        self.reg.lock().len(self.current_metasource),
+                        self.reg.lock().metasource_len(self.current_metasource),
                     );
                     self.state = State::Solver {
                         locale: self.state.get_locale().clone(),
@@ -254,10 +254,10 @@ where
             }
 
             let locale = self.locales.next()?;
-            self.current_metasource = self.reg.lock().metasources_len() - 1;
+            self.current_metasource = self.reg.lock().number_of_metasources() - 1;
             let solver = SerialProblemSolver::new(
                 self.res_ids.len(),
-                self.reg.lock().len(self.current_metasource),
+                self.reg.lock().metasource_len(self.current_metasource),
             );
             self.state = State::Solver { locale, solver };
         }

--- a/src/solver/parallel.rs
+++ b/src/solver/parallel.rs
@@ -42,6 +42,8 @@ impl<T: AsyncTester> ParallelProblemSolver<T> {
     }
 }
 
+type TestQuery = (Vec<(usize, usize)>, Vec<usize>);
+
 impl<T: AsyncTester> ParallelProblemSolver<T> {
     pub fn try_generate_complete_candidate(&mut self) -> bool {
         while !self.is_complete() {
@@ -57,7 +59,7 @@ impl<T: AsyncTester> ParallelProblemSolver<T> {
         true
     }
 
-    fn try_generate_test_query(&mut self) -> Result<(Vec<(usize, usize)>, Vec<usize>), usize> {
+    fn try_generate_test_query(&mut self) -> Result<TestQuery, usize> {
         let mut test_cells = vec![];
         let query = self
             .solution

--- a/src/solver/testing/mod.rs
+++ b/src/solver/testing/mod.rs
@@ -2,11 +2,20 @@ mod scenarios;
 
 pub use scenarios::get_scenarios;
 
+/// Define a testing scenario.
 pub struct Scenario {
+    /// Name of the scenario.
     pub name: String,
+    /// Number of resources.
     pub width: usize,
+    /// Number of sources.
     pub depth: usize,
+    /// Vector of resources, containing a vector of sources, with true indicating
+    /// whether the resource is present in that source.
     pub values: Vec<Vec<bool>>,
+    /// Vector of solutions, each containing a vector of resources, with the index
+    /// indicating from which source the resource is chosen.
+    /// TODO(issue#17): This field is currently unused!
     pub solutions: Vec<Vec<usize>>,
 }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -186,7 +186,6 @@ impl FileSource {
         }
     }
 
-
     pub fn set_reporter(&mut self, reporter: impl ErrorReporter + 'static) {
         let mut shared = Rc::get_mut(&mut self.shared).unwrap();
         shared.error_reporter = Some(RefCell::new(Box::new(reporter)));

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -186,6 +186,30 @@ impl FileSource {
         }
     }
 
+    pub fn new_with_index_and_metasource(
+        name: String,
+        metasource: String,
+        locales: Vec<LanguageIdentifier>,
+        pre_path: String,
+        options: FileSourceOptions,
+        fetcher: impl FileFetcher + 'static,
+        index: Vec<String>,
+    ) -> Self {
+        FileSource {
+            name,
+            metasource,
+            pre_path,
+            locales,
+            index: Some(index),
+            shared: Rc::new(Inner {
+                entries: RefCell::new(FxHashMap::default()),
+                fetcher: Box::new(fetcher),
+                error_reporter: None,
+            }),
+            options,
+        }
+    }
+
     pub fn set_reporter(&mut self, reporter: impl ErrorReporter + 'static) {
         let mut shared = Rc::get_mut(&mut self.shared).unwrap();
         shared.error_reporter = Some(RefCell::new(Box::new(reporter)));

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -362,6 +362,7 @@ impl std::fmt::Debug for FileSource {
         if let Some(index) = &self.index {
             f.debug_struct("FileSource")
                 .field("name", &self.name)
+                .field("metasource", &self.metasource)
                 .field("locales", &self.locales)
                 .field("pre_path", &self.pre_path)
                 .field("index", index)
@@ -369,6 +370,7 @@ impl std::fmt::Debug for FileSource {
         } else {
             f.debug_struct("FileSource")
                 .field("name", &self.name)
+                .field("metasource", &self.metasource)
                 .field("locales", &self.locales)
                 .field("pre_path", &self.pre_path)
                 .finish()

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -64,8 +64,11 @@ impl Future for ResourceStatus {
 /// implementation and `FileSource` takes care of the rest.
 #[derive(Clone)]
 pub struct FileSource {
+    /// Name of the FileSource, e.g. "browser"
     pub name: String,
+    /// Pre-formatted path for the FileSource, e.g. "/browser/data/locale/{locale}/"
     pub pre_path: String,
+    /// The locales for which data is present in the FileSource, e.g. ["en-US", "pl"]
     locales: Vec<LanguageIdentifier>,
     shared: Rc<Inner>,
     index: Option<Vec<String>>,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -68,6 +68,8 @@ pub struct FileSource {
     pub name: String,
     /// Pre-formatted path for the FileSource, e.g. "/browser/data/locale/{locale}/"
     pub pre_path: String,
+    /// Meta-source name for the FileSource, e.g. "browser", "lang-pack"
+    pub metasource: String,
     /// The locales for which data is present in the FileSource, e.g. ["en-US", "pl"]
     locales: Vec<LanguageIdentifier>,
     shared: Rc<Inner>,
@@ -89,7 +91,7 @@ impl fmt::Display for FileSource {
 
 impl PartialEq<FileSource> for FileSource {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
+        self.name == other.name && self.metasource == other.metasource
     }
 }
 
@@ -125,6 +127,7 @@ impl FileSource {
     ) -> Self {
         FileSource {
             name,
+            metasource: String::default(),
             pre_path,
             locales,
             index: None,
@@ -147,6 +150,7 @@ impl FileSource {
     ) -> Self {
         FileSource {
             name,
+            metasource: String::default(),
             pre_path,
             locales,
             index: Some(index),
@@ -158,6 +162,30 @@ impl FileSource {
             options,
         }
     }
+
+    pub fn new_with_metasource(
+        name: String,
+        metasource: String,
+        locales: Vec<LanguageIdentifier>,
+        pre_path: String,
+        options: FileSourceOptions,
+        fetcher: impl FileFetcher + 'static,
+    ) -> Self {
+        FileSource {
+            name,
+            metasource,
+            pre_path,
+            locales,
+            index: None,
+            shared: Rc::new(Inner {
+                entries: RefCell::new(FxHashMap::default()),
+                fetcher: Box::new(fetcher),
+                error_reporter: None,
+            }),
+            options,
+        }
+    }
+
 
     pub fn set_reporter(&mut self, reporter: impl ErrorReporter + 'static) {
         let mut shared = Rc::get_mut(&mut self.shared).unwrap();

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -19,6 +19,7 @@ pub struct RegistrySetup {
 
 pub struct FileSource {
     pub name: String,
+    pub metasource: String,
     pub locales: Vec<LanguageIdentifier>,
     pub path_scheme: String,
 }
@@ -37,6 +38,24 @@ impl FileSource {
     {
         Self {
             name: name.to_string(),
+            metasource: String::default(),
+            locales,
+            path_scheme: path_scheme.to_string(),
+        }
+    }
+
+    pub fn new_with_metasource<S>(
+        name: S,
+        metasource: S,
+        locales: Vec<LanguageIdentifier>,
+        path_scheme: S,
+    ) -> Self
+    where
+        S: ToString,
+    {
+        Self {
+            name: name.to_string(),
+            metasource: metasource.to_string(),
             locales,
             path_scheme: path_scheme.to_string(),
         }
@@ -137,6 +156,23 @@ impl TestFileFetcher {
         )
     }
 
+    pub fn get_test_file_source_with_metasource(
+        &self,
+        name: &str,
+        metasource: &str,
+        locales: Vec<LanguageIdentifier>,
+        path: &str,
+    ) -> crate::source::FileSource {
+        crate::source::FileSource::new_with_metasource(
+            name.to_string(),
+            metasource.to_string(),
+            locales,
+            path.to_string(),
+            Default::default(),
+            self.clone(),
+        )
+    }
+
     pub fn get_test_file_source_with_index(
         &self,
         name: &str,
@@ -179,8 +215,12 @@ impl TestFileFetcher {
             .file_sources
             .into_iter()
             .map(|source| {
-                let mut s =
-                    self.get_test_file_source(&source.name, source.locales, &source.path_scheme);
+                let mut s = self.get_test_file_source_with_metasource(
+                    &source.name,
+                    &source.metasource,
+                    source.locales,
+                    &source.path_scheme,
+                );
                 s.set_reporter(provider.clone());
                 s
             })

--- a/tests/localization.rs
+++ b/tests/localization.rs
@@ -88,7 +88,9 @@ fn localization_format_value_sync() {
     let mut errors = vec![];
 
     for query in &[L10N_ID_PL_EN, L10N_ID_MISSING, L10N_ID_ONLY_EN] {
-        let value = bundles.format_value_sync(query.0, None, &mut errors).unwrap();
+        let value = bundles
+            .format_value_sync(query.0, None, &mut errors)
+            .unwrap();
         assert_eq!(value, query.1.map(|s| Cow::Borrowed(s)));
     }
 
@@ -178,6 +180,8 @@ async fn localization_upgrade() {
 
     loc.set_async();
     let bundles = loc.bundles();
-    let value = bundles.format_value(L10N_ID_PL_EN.0, None, &mut errors).await;
+    let value = bundles
+        .format_value(L10N_ID_PL_EN.0, None, &mut errors)
+        .await;
     assert_eq!(value, L10N_ID_PL_EN.1.map(|s| Cow::Borrowed(s)));
 }

--- a/tests/localization.rs
+++ b/tests/localization.rs
@@ -35,8 +35,18 @@ fn get_l10n_registry() -> &'static L10nRegistry {
         let setup = RegistrySetup::new(
             "test",
             vec![
-                FileSource::new("toolkit", get_app_locales().to_vec(), "toolkit/{locale}/"),
-                FileSource::new("browser", get_app_locales().to_vec(), "browser/{locale}/"),
+                FileSource::new(
+                    "toolkit",
+                    None,
+                    get_app_locales().to_vec(),
+                    "toolkit/{locale}/",
+                ),
+                FileSource::new(
+                    "browser",
+                    None,
+                    get_app_locales().to_vec(),
+                    "browser/{locale}/",
+                ),
             ],
             get_app_locales().to_vec(),
         );

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -10,8 +10,8 @@ fn test_generate_sources_for_file() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
         ],
         vec![en_us.clone()],
     );
@@ -54,8 +54,8 @@ fn test_generate_bundles_for_lang_sync() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
         ],
         vec![en_us.clone()],
     );
@@ -75,8 +75,8 @@ fn test_generate_bundles_sync() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
         ],
         vec![en_us.clone()],
     );
@@ -99,8 +99,8 @@ async fn test_generate_bundles_for_lang() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
         ],
         vec![en_us.clone()],
     );
@@ -122,8 +122,8 @@ async fn test_generate_bundles() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
         ],
         vec![en_us.clone()],
     );
@@ -144,8 +144,8 @@ fn test_manage_sources() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new("toolkit", vec![en_us.clone()], "toolkit/{locale}/"),
-            FileSource::new("browser", vec![en_us.clone()], "browser/{locale}/"),
+            FileSource::new("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/"),
+            FileSource::new("browser", None, vec![en_us.clone()], "browser/{locale}/"),
         ],
         vec![en_us.clone()],
     );
@@ -176,6 +176,7 @@ fn test_manage_sources() {
 
     reg.register_sources(vec![fetcher.get_test_file_source(
         "toolkit",
+        None,
         lang_ids.clone(),
         "browser/{locale}/",
     )])
@@ -187,6 +188,7 @@ fn test_manage_sources() {
 
     reg.update_sources(vec![fetcher.get_test_file_source(
         "toolkit",
+        None,
         lang_ids.clone(),
         "toolkit/{locale}/",
     )])
@@ -204,27 +206,27 @@ fn test_generate_bundles_with_metasources_sync() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "toolkit",
-                "app",
+                Some("app"),
                 vec![en_us.clone()],
                 "toolkit/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "browser",
-                "app",
+                Some("app"),
                 vec![en_us.clone()],
                 "browser/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "toolkit",
-                "langpack",
+                Some("langpack"),
                 vec![en_us.clone()],
                 "toolkit/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "browser",
-                "langpack",
+                Some("langpack"),
                 vec![en_us.clone()],
                 "browser/{locale}/",
             ),
@@ -252,27 +254,27 @@ async fn test_generate_bundles_with_metasources() {
     let setup = RegistrySetup::new(
         "test",
         vec![
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "toolkit",
-                "app",
+                Some("app"),
                 vec![en_us.clone()],
                 "toolkit/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "browser",
-                "app",
+                Some("app"),
                 vec![en_us.clone()],
                 "browser/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "toolkit",
-                "langpack",
+                Some("langpack"),
                 vec![en_us.clone()],
                 "toolkit/{locale}/",
             ),
-            FileSource::new_with_metasource(
+            FileSource::new(
                 "browser",
-                "langpack",
+                Some("langpack"),
                 vec![en_us.clone()],
                 "browser/{locale}/",
             ),

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -291,4 +291,3 @@ async fn test_generate_bundles_with_metasources() {
     assert!(i.next().await.is_some());
     assert!(i.next().await.is_none());
 }
-

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -21,10 +21,10 @@ fn test_generate_sources_for_file() {
     {
         let lock = reg.lock();
 
-        let toolkit = lock.get_source("toolkit").unwrap();
-        let browser = lock.get_source("browser").unwrap();
+        let toolkit = lock.get_source(0, "toolkit").unwrap();
+        let browser = lock.get_source(0, "browser").unwrap();
 
-        let mut i = lock.generate_sources_for_file(&en_us, FTL_RESOURCE_TOOLKIT);
+        let mut i = lock.generate_sources_for_file(0, &en_us, FTL_RESOURCE_TOOLKIT);
 
         assert_eq!(i.next(), Some(toolkit));
         assert_eq!(i.next(), Some(browser));
@@ -34,7 +34,7 @@ fn test_generate_sources_for_file() {
             .fetch_file_sync(&en_us, FTL_RESOURCE_TOOLKIT, false)
             .is_none());
 
-        let mut i = lock.generate_sources_for_file(&en_us, FTL_RESOURCE_TOOLKIT);
+        let mut i = lock.generate_sources_for_file(0, &en_us, FTL_RESOURCE_TOOLKIT);
         assert_eq!(i.next(), Some(toolkit));
         assert_eq!(i.next(), None);
 
@@ -42,7 +42,7 @@ fn test_generate_sources_for_file() {
             .fetch_file_sync(&en_us, FTL_RESOURCE_TOOLKIT, false)
             .is_some());
 
-        let mut i = lock.generate_sources_for_file(&en_us, FTL_RESOURCE_TOOLKIT);
+        let mut i = lock.generate_sources_for_file(0, &en_us, FTL_RESOURCE_TOOLKIT);
         assert_eq!(i.next(), Some(toolkit));
         assert_eq!(i.next(), None);
     }
@@ -194,6 +194,50 @@ fn test_manage_sources() {
 
     let paths = vec![FTL_RESOURCE_TOOLKIT.into(), FTL_RESOURCE_BROWSER.into()];
     let mut i = reg.generate_bundles_sync(lang_ids.clone().into_iter(), paths);
+    assert!(i.next().is_some());
+    assert!(i.next().is_none());
+}
+
+#[test]
+fn test_generate_bundles_with_metasources_sync() {
+    let en_us: LanguageIdentifier = "en-US".parse().unwrap();
+    let setup = RegistrySetup::new(
+        "test",
+        vec![
+            FileSource::new_with_metasource(
+                "toolkit",
+                "app",
+                vec![en_us.clone()],
+                "toolkit/{locale}/",
+            ),
+            FileSource::new_with_metasource(
+                "browser",
+                "app",
+                vec![en_us.clone()],
+                "browser/{locale}/",
+            ),
+            FileSource::new_with_metasource(
+                "toolkit",
+                "langpack",
+                vec![en_us.clone()],
+                "toolkit/{locale}/",
+            ),
+            FileSource::new_with_metasource(
+                "browser",
+                "langpack",
+                vec![en_us.clone()],
+                "browser/{locale}/",
+            ),
+        ],
+        vec![en_us.clone()],
+    );
+    let fetcher = TestFileFetcher::new();
+    let (_, reg) = fetcher.get_registry_and_environment(setup);
+
+    let paths = vec![FTL_RESOURCE_TOOLKIT.into(), FTL_RESOURCE_BROWSER.into()];
+    let lang_ids = vec![en_us];
+    let mut i = reg.generate_bundles_sync(lang_ids.into_iter(), paths);
+
     assert!(i.next().is_some());
     assert!(i.next().is_none());
 }

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -10,7 +10,8 @@ fn test_fetch_sync() {
     let fetcher = TestFileFetcher::new();
     let en_us: LanguageIdentifier = "en-US".parse().unwrap();
 
-    let fs1 = fetcher.get_test_file_source("toolkit", vec![en_us.clone()], "toolkit/{locale}/");
+    let fs1 =
+        fetcher.get_test_file_source("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/");
 
     assert!(fs1
         .fetch_file_sync(&en_us, FTL_RESOURCE_PRESENT, false)
@@ -25,7 +26,8 @@ async fn test_fetch_async() {
     let fetcher = TestFileFetcher::new();
     let en_us: LanguageIdentifier = "en-US".parse().unwrap();
 
-    let fs1 = fetcher.get_test_file_source("toolkit", vec![en_us.clone()], "toolkit/{locale}/");
+    let fs1 =
+        fetcher.get_test_file_source("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/");
 
     assert!(fs1.fetch_file(&en_us, FTL_RESOURCE_PRESENT).await.is_some());
     assert!(fs1.fetch_file(&en_us, FTL_RESOURCE_MISSING).await.is_none());
@@ -37,7 +39,8 @@ async fn test_fetch_sync_2_async() {
     let fetcher = TestFileFetcher::new();
     let en_us: LanguageIdentifier = "en-US".parse().unwrap();
 
-    let fs1 = fetcher.get_test_file_source("toolkit", vec![en_us.clone()], "toolkit/{locale}/");
+    let fs1 =
+        fetcher.get_test_file_source("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/");
 
     assert!(fs1
         .fetch_file_sync(&en_us, FTL_RESOURCE_PRESENT, false)
@@ -53,7 +56,8 @@ async fn test_fetch_async_2_sync() {
     let fetcher = TestFileFetcher::new();
     let en_us: LanguageIdentifier = "en-US".parse().unwrap();
 
-    let fs1 = fetcher.get_test_file_source("toolkit", vec![en_us.clone()], "toolkit/{locale}/");
+    let fs1 =
+        fetcher.get_test_file_source("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/");
 
     assert!(fs1.fetch_file(&en_us, FTL_RESOURCE_PRESENT).await.is_some());
     assert!(fs1
@@ -68,7 +72,8 @@ fn test_fetch_has_value_sync() {
     let path = FTL_RESOURCE_PRESENT;
     let path_missing = FTL_RESOURCE_MISSING;
 
-    let fs1 = fetcher.get_test_file_source("toolkit", vec![en_us.clone()], "toolkit/{locale}/");
+    let fs1 =
+        fetcher.get_test_file_source("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/");
 
     assert_eq!(fs1.has_file(&en_us, path), None);
     assert!(fs1.fetch_file_sync(&en_us, path, false).is_some());
@@ -86,7 +91,8 @@ async fn test_fetch_has_value_async() {
     let path = FTL_RESOURCE_PRESENT;
     let path_missing = FTL_RESOURCE_MISSING;
 
-    let fs1 = fetcher.get_test_file_source("toolkit", vec![en_us.clone()], "toolkit/{locale}/");
+    let fs1 =
+        fetcher.get_test_file_source("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/");
 
     assert_eq!(fs1.has_file(&en_us, path), None);
     assert!(fs1.fetch_file(&en_us, path).await.is_some());
@@ -104,7 +110,8 @@ async fn test_fetch_async_consequitive() {
     let fetcher = TestFileFetcher::new();
     let en_us: LanguageIdentifier = "en-US".parse().unwrap();
 
-    let fs1 = fetcher.get_test_file_source("toolkit", vec![en_us.clone()], "toolkit/{locale}/");
+    let fs1 =
+        fetcher.get_test_file_source("toolkit", None, vec![en_us.clone()], "toolkit/{locale}/");
 
     let results = join_all(vec![
         fs1.fetch_file(&en_us, FTL_RESOURCE_PRESENT),
@@ -126,6 +133,7 @@ fn test_indexed() {
 
     let fs1 = fetcher.get_test_file_source_with_index(
         "toolkit",
+        None,
         vec![en_us.clone()],
         "toolkit/{locale}/",
         vec!["toolkit/en-US/toolkit/global/textActions.ftl"],


### PR DESCRIPTION
This adds metasource to FileSource and groups sources by metasource in the registry. Only sources with the same metasource are passed into the solver.

This is WIP, so far it is only implemented for the synchronous registry. This adds one test, I've checked manually using it that the bundle is built from the "langpack" sources as expected. Next steps are support for the asynchronous registry and further tests.

Fixes #12.