### PR TITLE
By default handle sync-during-async file fetch with overload rather than crash.

### DIFF
--- a/src/registry/synchronous.rs
+++ b/src/registry/synchronous.rs
@@ -29,7 +29,7 @@ impl<'a, B> L10nRegistryLocked<'a, B> {
 
         for (&source_idx, path) in source_order.iter().zip(res_ids.iter()) {
             let source = self.source_idx(source_idx);
-            if let Some(res) = source.fetch_file_sync(&locale, path, false) {
+            if let Some(res) = source.fetch_file_sync(&locale, path, /* overload */ true) {
                 if source.options.allow_override {
                     bundle.add_resource_overriding(res);
                 } else if let Err(err) = bundle.add_resource(res) {


### PR DESCRIPTION
Fixing https://bugzilla.mozilla.org/show_bug.cgi?id=1723187