### PR TITLE
Use crates.io for fluent-rs dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-fluent-bundle = { git = "https://github.com/projectfluent/fluent-rs.git", rev = "94b1601df5c3d8aceb09cb34e99e2e3239e4958f" }
-fluent-fallback = { git = "https://github.com/projectfluent/fluent-rs.git", rev = "94b1601df5c3d8aceb09cb34e99e2e3239e4958f" }
-fluent-testing = { git = "https://github.com/projectfluent/fluent-rs.git", rev = "94b1601df5c3d8aceb09cb34e99e2e3239e4958f", optional = true, features = ["sync", "async"] }
+fluent-bundle = "0.15.2"
+fluent-fallback = "0.6.0"
+fluent-testing = { version = "0.0.1", features = ["sync", "async"] }
 futures = "0.3"
 pin-project-lite = "0.2"
 unic-langid = "0.9"
@@ -25,53 +25,54 @@ criterion = "0.3"
 [features]
 default = []
 tokio-io = ["tokio"]
+test-fluent = []
 
 [[bench]]
 name = "preferences"
 harness = false
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[bench]]
 name = "localization"
 harness = false
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[bench]]
 name = "source"
 harness = false
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[bench]]
 name = "solver"
 harness = false
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[bench]]
 name = "registry"
 harness = false
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[test]]
 name = "source"
 path = "tests/source.rs"
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[test]]
 name = "registry"
 path = "tests/registry.rs"
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[test]]
 name = "localization"
 path = "tests/localization.rs"
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]
 
 [[test]]
 name = "scenarios_sync"
 path = "tests/scenarios_sync.rs"
-required-features = ["fluent-testing"]
+required-features = ["test-fluent"]
 
 [[test]]
 name = "scenarios_async"
 path = "tests/scenarios_async.rs"
-required-features = ["tokio", "fluent-testing"]
+required-features = ["tokio", "test-fluent"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,5 @@ pub mod fluent;
 pub mod registry;
 pub mod solver;
 pub mod source;
-#[cfg(feature = "fluent-testing")]
+#[cfg(feature = "test-fluent")]
 pub mod testing;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -488,7 +488,7 @@ key2 = Value 2
 }
 
 #[cfg(test)]
-#[cfg(feature = "tokio")]
+#[cfg(all(feature = "tokio", feature = "test-fluent"))]
 mod tests_tokio {
     use super::*;
     use crate::testing::TestFileFetcher;


### PR DESCRIPTION
Now that fluent-testing is published, we can use crates.io
instead of a git revision for these dependencies.

I had to rename the `fluent-testing` feature flag so that there is no conflict with the dependency name. This apparently matters for crates.io dependencies, but not for git rev dependencies.