### PR TITLE
Make fluent-testing crate optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 async-trait = "0.1"
 fluent-bundle = "0.15.2"
 fluent-fallback = "0.6.0"
-fluent-testing = { version = "0.0.1", features = ["sync", "async"] }
+fluent-testing = { version = "0.0.1", optional = true, features = ["sync", "async"] }
 futures = "0.3"
 pin-project-lite = "0.2"
 unic-langid = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 async-trait = "0.1"
 fluent-bundle = "0.15.2"
 fluent-fallback = "0.6.0"
-fluent-testing = { version = "0.0.1", optional = true, features = ["sync", "async"] }
+fluent-testing = { version = "0.0.2", optional = true, features = ["sync", "async"] }
 futures = "0.3"
 pin-project-lite = "0.2"
 unic-langid = "0.9"

--- a/benches/preferences.rs
+++ b/benches/preferences.rs
@@ -26,7 +26,11 @@ fn preferences_bench(c: &mut Criterion) {
                 let reg = fetcher.get_registry(&scenario);
                 let mut bundles =
                     reg.generate_bundles_sync(locales.clone().into_iter(), res_ids.clone());
-                assert!(bundles.next().is_some());
+                for _ in 0..locales.len() {
+                    if bundles.next().is_some() {
+                        break;
+                    }
+                }
             })
         });
 
@@ -43,7 +47,11 @@ fn preferences_bench(c: &mut Criterion) {
 
                         let mut bundles =
                             reg.generate_bundles(locales.clone().into_iter(), res_ids.clone());
-                        assert!(bundles.next().await.is_some());
+                        for _ in 0..locales.len() {
+                            if bundles.next().await.is_some() {
+                                break;
+                            }
+                        }
                     });
                 })
             });

--- a/benches/registry.rs
+++ b/benches/registry.rs
@@ -3,10 +3,11 @@ use criterion::criterion_main;
 use criterion::Criterion;
 
 use futures::stream::StreamExt;
+use l10nregistry::source::ResourceId;
 use l10nregistry::testing::{FileSource, RegistrySetup, TestFileFetcher};
 use unic_langid::LanguageIdentifier;
 
-fn get_paths() -> Vec<String> {
+fn get_paths() -> Vec<ResourceId> {
     let paths: Vec<&'static str> = vec![
         "branding/brand.ftl",
         "browser/sanitize.ftl",
@@ -27,7 +28,7 @@ fn get_paths() -> Vec<String> {
         "toolkit/featuregates/features.ftl",
     ];
 
-    paths.iter().map(|s| s.to_string()).collect()
+    paths.into_iter().map(ResourceId::from).collect()
 }
 
 fn registry_bench(c: &mut Criterion) {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -312,7 +312,8 @@ impl ErrorReporter for TestEnvironment {
                 panic!("Errors: {:#?}", errors);
             }
             ErrorStrategy::Report => {
-                println!("Errors: {:#?}", errors);
+                #[cfg(test)] // Don't let printing affect benchmarks
+                eprintln!("Errors: {:#?}", errors);
             }
             ErrorStrategy::Nothing => {}
         }


### PR DESCRIPTION
I explored the options of making `fluent-testing` a dev dependency vs. an optional dependency. 

Note that a dependency cannot be both dev and optional. 

`fluent-testing` cannot be a dev dependency because our l10nregistry-rs integration tests rely on it. dev-dependency items which are usually exposed under `cfg(test)` are not exposed to the `tests` directory where integration tests exist.

I believe the cleanest path forward is to keep `fluent-testing` as an optional dependency. 

I also noticed that the benchmarks were failing because I never changed those to use `ResourceId` instead of string. (It looks like we don't have CI set up to run benches).

This patch makes `fluent-testing` an optional dependency and fixes the benchmarks.